### PR TITLE
Support lighting up trees

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -1,7 +1,7 @@
-name = "ActionQueue RB3 - with endless action"
-description = ""
 author = "Cutlass / null / eXiGe / simplex(Original Author)"
-version = "2.9.03"
+version = "2.9.04"
+name = "ActionQueue RB3 - with endless action v" .. version
+description = ""
 api_version_dst = 10
 
 icon_atlas = "modicon.xml"

--- a/scripts/components/actionqueuer.lua
+++ b/scripts/components/actionqueuer.lua
@@ -223,7 +223,8 @@ AddActionList(
     "ERASE_PAPER",
     "PICK",
     "BOTTLE",
-	"WAX"
+    "WAX",
+    "GRAVEDIG"	-- 250304 VanCa: Added support for Wendy's skill
 )
 
 AddAction(
@@ -564,6 +565,15 @@ AddAction(
     end
 )
 
+-- 241001 VanCa: added support for lighting up trees
+AddAction(
+    "rightclick",
+    "LIGHT",
+    function(target)
+        return target:HasTag("tree")
+    end
+)
+
 --[[single]]
 AddActionList("single", "CASTSPELL", "DECORATEVASE", "REPAIR_LEAK")
 
@@ -580,7 +590,7 @@ AddActionList(
     "FERTILIZE",
     "FILL",
     "HAMMER",
-    -- "HARVEST", 241004 Vanca: harvest is long action, right?
+    "HARVEST",
     "HEAL",
     "MINE",
     "PLANT",
@@ -588,7 +598,8 @@ AddActionList(
     "TERRAFORM",
     "ADDCOMPOSTABLE",
     "DEPLOY_TILEARRIVE",
-    "PICKUP"
+    "PICKUP",
+    "LIGHT"
 )
 
 AddAction(
@@ -2877,6 +2888,9 @@ function ActionQueuer:ClearSelectedEntities()
     self.last_target_ent = nil
     for ent in pairs(self.selected_ents) do
         self:DeselectEntity(ent)
+    end	
+    for tile in pairs(self.selected_farm_tiles) do
+        self:DeselectFarmTile(tile)
     end
 end
 


### PR DESCRIPTION
Support light up trees. Fix a bug that tiles selection won't clear when the queue get canceled.