### PR TITLE
2.9.11

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -1,5 +1,5 @@
 author = "Cutlass / null / eXiGe / simplex(Original Author)"
-version = "2.9.09"
+version = "2.9.11"
 name = "ActionQueue RB3 - with endless action v" .. version
 description = ""
 api_version_dst = 10


### PR DESCRIPTION
2.9.11:
Game server prevents Wormwood from talking to or picking plants while holding a shovel, this previously causing him to stand still. Now, the shovel will automatically unequip, allowing him to smoothly excute the action queue.

2.9.10:
Exclude STORE chests to draw minisign with click&drag easily.