### PR TITLE
3.1.07

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -215,7 +215,7 @@ F5を押して無限配置を有効化、またはMOD設定でデフォルトを
 
 -- Mod metadata
 author = "simplex (Original Author)"
-version = "3.1.06"
+version = "3.1.07"
 name = "ActionQueue RB3 - with endless action v" .. version
 folder_name = folder_name or "action queue"
 if not folder_name:find("workshop-") then


### PR DESCRIPTION
Select all variations of deer antlers

Only pick up blueprints with the same name (useful when there are dozens of blueprints under the Monkey Queen)

Make storing food into gelblob_storage easier: shift + store into any gelblob_storage, the nearest valid one will be selected automatically.