### PR TITLE
3.2.01

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -215,7 +215,7 @@ F5を押して無限配置を有効化、またはMOD設定でデフォルトを
 
 -- Mod metadata
 author = "simplex (Original Author)"
-version = "3.1.07"
+version = "3.2.01"
 name = "ActionQueue RB3 - with endless action v" .. version
 folder_name = folder_name or "action queue"
 if not folder_name:find("workshop-") then

--- a/scripts/components/actionqueuer.lua
+++ b/scripts/components/actionqueuer.lua
@@ -2007,6 +2007,14 @@ function ActionQueuer:DoubleClick(rightclick, target)
                 end
             end
         end
+    elseif target.action == ACTIONS.REMOVELUNARBUILDUP then
+        -- 250919 VanCa: Select all nearby prefab that has lunar hail builded-up
+        for _, ent in pairs(TheSim:FindEntities(x, 0, z, self.double_click_range, nil, unselectable_tags)) do
+            local act, rightclick_ = self:GetAction(ent, rightclick)
+            if act and act.action == target.action then
+                self:SelectEntity(ent, rightclick_)
+            end
+        end
     else
         DebugPrint("Not a special target:", target.prefab)
         -- 210705 null: added support for other mods to add their own CherryPick conditions

--- a/scripts/components/actionqueuer.lua
+++ b/scripts/components/actionqueuer.lua
@@ -473,6 +473,16 @@ AddAction(
     end
 )
 
+-- 250919 VanCa: Added support for mining Luna Hail == Cutlass 3.2 + Fix a stuck on burn trees
+AddAction(
+    "leftclick",
+    "REMOVELUNARBUILDUP",
+    function(target)
+        -- Fix a stuck on burn trees
+        return not (target:HasTag("burnt") or target:HasTag("fire"))
+    end
+)
+
 --[[rightclick]]
 AddActionList(
     "rightclick",


### PR DESCRIPTION
Updated to ActionQueue RB3 3.2:
Added support for mining Luna Hail.

Select all nearby prefab that has lunar hail builded-up.
Prevent stuck when "Clear" burned prefabs.